### PR TITLE
Fix bear scoring

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -3655,7 +3655,7 @@ function calculateBearTokenScoring() {
 					}
 				}
 				if(potentialTokenIDs.length == 2) {
-					if(confirmedBearPairs <= 4) confirmedBearPairs++;
+					if(confirmedBearPairs < 4) confirmedBearPairs++;
 				}
 			}
 			usedTokenIDs.push(...potentialTokenIDs);


### PR DESCRIPTION
The bear A scoring should still work if we have more than 4 pairs of bear. As 4 and above scores the same, we only need to count up to 4.